### PR TITLE
[Feature/DATEPICK-206]: Tags API 구현

### DIFF
--- a/src/main/java/app/hdj/datepick/domain/tag/controller/TagController.java
+++ b/src/main/java/app/hdj/datepick/domain/tag/controller/TagController.java
@@ -1,8 +1,24 @@
 package app.hdj.datepick.domain.tag.controller;
 
+import app.hdj.datepick.domain.tag.entity.Tag;
+import app.hdj.datepick.domain.tag.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
+@RequiredArgsConstructor
 @RestController
+@RequestMapping("v1/tags")
 public class TagController {
+
+    private final TagService tagService;
+
+    @GetMapping("")
+    public List<Tag> getTagList() {
+        return tagService.getTagList();
+    }
 
 }

--- a/src/main/java/app/hdj/datepick/domain/tag/entity/Tag.java
+++ b/src/main/java/app/hdj/datepick/domain/tag/entity/Tag.java
@@ -15,7 +15,7 @@ import javax.persistence.Entity;
 @Entity
 public class Tag extends BaseEntity<Byte> {
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Column

--- a/src/main/java/app/hdj/datepick/domain/tag/repository/TagRepository.java
+++ b/src/main/java/app/hdj/datepick/domain/tag/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package app.hdj.datepick.domain.tag.repository;
+
+import app.hdj.datepick.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Byte> {
+
+}

--- a/src/main/java/app/hdj/datepick/domain/tag/service/TagService.java
+++ b/src/main/java/app/hdj/datepick/domain/tag/service/TagService.java
@@ -1,0 +1,22 @@
+package app.hdj.datepick.domain.tag.service;
+
+import app.hdj.datepick.domain.tag.entity.Tag;
+import app.hdj.datepick.domain.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public List<Tag> getTagList() {
+        return tagRepository.findAll();
+    }
+
+}


### PR DESCRIPTION
## 작업 프로젝트 링크
- [DATEPICK-206 | Tags API 구현](https://handongju.atlassian.net/browse/DATEPICK-206)

## 작업한 내용
- [x] 기본적인 Tags API 구현 (딸랑 1개)

## 비고
- Tag Entity 안에 있는 course_count는 일단 스케줄링을 통해 1시간에 한번 정도 `COUNT` 쿼리를 통해 업데이트 해줄 생각임 (그다지 실시간성이 중요한 수치가 아니라 생각해서 굳이 Redis 캐싱을 안하는 방향으로 구상함)
- 차후에 **푸시 메시지 서버**가 구축되면, 태그를 **구독**해서 새로운 코스가 추가되면 푸시 메시지를 날려주는 기능을 넣을 수도 있을꺼라 생각함