### PR TITLE
[feature/DATEPICK-209]: Comment API 구현

### DIFF
--- a/src/main/java/app/hdj/datepick/domain/comment/controller/CommentController.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/controller/CommentController.java
@@ -1,0 +1,58 @@
+package app.hdj.datepick.domain.comment.controller;
+
+import app.hdj.datepick.domain.comment.dto.CommentFilterParam;
+import app.hdj.datepick.domain.comment.dto.CommentPublic;
+import app.hdj.datepick.domain.comment.dto.CommentRequest;
+import app.hdj.datepick.domain.comment.service.CommentService;
+import app.hdj.datepick.global.common.CustomPage;
+import app.hdj.datepick.global.common.PagingParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("v1/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("")
+    CustomPage<CommentPublic> getCommentPage(@Valid PagingParam pagingParam,
+                                             @Valid CommentFilterParam commentFilterParam) {
+        return commentService.getCommentPage(pagingParam, commentFilterParam);
+    }
+
+    @GetMapping("me")
+    CustomPage<CommentPublic> getMyCommentPage(@AuthenticationPrincipal Long userId,
+                                               @Valid PagingParam pagingParam) {
+        return commentService.getMyCommentPage(pagingParam, userId);
+    }
+
+    @PostMapping("")
+    CommentPublic addComment(@AuthenticationPrincipal Long userId,
+                             @Valid CommentFilterParam commentFilterParam,
+                             @Valid @RequestBody CommentRequest commentRequest) {
+        return commentService.addComment(commentFilterParam, commentRequest, userId);
+    }
+
+    @PatchMapping("{commentId}")
+    CommentPublic modifyComment(@AuthenticationPrincipal Long userId,
+                                @PathVariable Long commentId,
+                                @Valid @RequestBody CommentRequest commentRequest) {
+        return commentService.modifyComment(commentId, commentRequest, userId);
+    }
+
+    @DeleteMapping("{commentId}")
+    void removeComment(@AuthenticationPrincipal Long userId,
+                       @PathVariable Long commentId) {
+        commentService.removeComment(commentId, userId);
+    }
+
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/dto/CommentFilterParam.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/dto/CommentFilterParam.java
@@ -1,0 +1,20 @@
+package app.hdj.datepick.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+@Getter
+@AllArgsConstructor
+public class CommentFilterParam {
+
+    @NotNull
+    @Positive
+    private Long courseId;
+
+    @Positive
+    private Long parentId;
+
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/dto/CommentPublic.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/dto/CommentPublic.java
@@ -1,0 +1,40 @@
+package app.hdj.datepick.domain.comment.dto;
+
+import app.hdj.datepick.domain.comment.entity.Comment;
+import app.hdj.datepick.domain.user.dto.UserPublic;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentPublic {
+
+    private Long id;
+    private String content;
+    private Long courseId;
+    private Long parentId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private UserPublic user;
+
+    public static CommentPublic from(Comment comment) {
+        UserPublic user = new UserPublic(
+                comment.getUser().getId(),
+                comment.getUser().getNickname(),
+                comment.getUser().getGender(),
+                comment.getUser().getImageUrl()
+        );
+        return new CommentPublic(
+                comment.getId(),
+                comment.getContent(),
+                comment.getCourse().getId(),
+                comment.getParent() != null ? comment.getParent().getId() : null,
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
+                user
+        );
+    }
+
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,15 @@
+package app.hdj.datepick.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+
+    @NotEmpty
+    private String content;
+
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,11 @@
+package app.hdj.datepick.domain.comment.repository;
+
+import app.hdj.datepick.domain.comment.dto.CommentFilterParam;
+import app.hdj.datepick.domain.comment.entity.Comment;
+import app.hdj.datepick.global.common.PagingParam;
+import org.springframework.data.domain.Page;
+
+public interface CommentCustomRepository {
+    Page<Comment> findCommentPage(PagingParam pagingParam, CommentFilterParam commentFilterParam);
+    Page<Comment> findMyCommentPage(PagingParam pagingParam, Long userId);
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,0 +1,62 @@
+package app.hdj.datepick.domain.comment.repository;
+
+import app.hdj.datepick.domain.comment.dto.CommentFilterParam;
+import app.hdj.datepick.domain.comment.entity.Comment;
+import app.hdj.datepick.global.common.PagingParam;
+import app.hdj.datepick.global.util.PagingUtil;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import static app.hdj.datepick.domain.comment.entity.QComment.comment;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final PagingUtil pagingUtil;
+
+    @Override
+    public Page<Comment> findCommentPage(PagingParam pagingParam, CommentFilterParam commentFilterParam) {
+        JPAQuery<Comment> query = jpaQueryFactory
+                .selectFrom(comment);
+        query = filterComments(query, commentFilterParam);
+        PageRequest pageRequest = PageRequest.of(pagingParam.getPage(), pagingParam.getSize(), Sort.by("createdAt").descending());
+        return pagingUtil.getPageImpl(pageRequest, query);
+    }
+
+    private JPAQuery<Comment> filterComments(JPAQuery<Comment> query, CommentFilterParam commentFilterParam) {
+        query = filterCourse(commentFilterParam.getCourseId(), query);
+        if (commentFilterParam.getParentId() != null) {
+            query = filterParent(commentFilterParam.getParentId(), query);
+        } else {
+            query = query.where(comment.parent.isNull());
+        }
+        return query;
+    }
+
+    private JPAQuery<Comment> filterCourse(Long courseId, JPAQuery<Comment> query) {
+        return query.where(comment.course.id.eq(courseId));
+    }
+
+    private JPAQuery<Comment> filterParent(Long parentId, JPAQuery<Comment> query) {
+        return query.where(comment.parent.id.eq(parentId));
+    }
+
+    @Override
+    public Page<Comment> findMyCommentPage(PagingParam pagingParam, Long userId) {
+        JPAQuery<Comment> query = jpaQueryFactory
+                .selectFrom(comment)
+                .where(comment.user.id.eq(userId));
+        PageRequest pageRequest = PageRequest.of(pagingParam.getPage(), pagingParam.getSize(), Sort.by("createdAt").descending());
+        return pagingUtil.getPageImpl(pageRequest, query);
+    }
+
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package app.hdj.datepick.domain.comment.repository;
+
+import app.hdj.datepick.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+public interface CommentRepository extends
+        JpaRepository<Comment, Long>,
+        CommentCustomRepository,
+        QuerydslPredicateExecutor<Comment> {
+}

--- a/src/main/java/app/hdj/datepick/domain/comment/service/CommentService.java
+++ b/src/main/java/app/hdj/datepick/domain/comment/service/CommentService.java
@@ -1,0 +1,100 @@
+package app.hdj.datepick.domain.comment.service;
+
+import app.hdj.datepick.domain.comment.dto.CommentFilterParam;
+import app.hdj.datepick.domain.comment.dto.CommentPublic;
+import app.hdj.datepick.domain.comment.dto.CommentRequest;
+import app.hdj.datepick.domain.comment.entity.Comment;
+import app.hdj.datepick.domain.comment.repository.CommentRepository;
+import app.hdj.datepick.domain.course.entity.Course;
+import app.hdj.datepick.domain.user.entity.User;
+import app.hdj.datepick.domain.user.repository.UserRepository;
+import app.hdj.datepick.global.common.CustomPage;
+import app.hdj.datepick.global.common.PagingParam;
+import app.hdj.datepick.global.error.enums.ErrorCode;
+import app.hdj.datepick.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    public CustomPage<CommentPublic> getCommentPage(PagingParam pagingParam,
+                                                    CommentFilterParam commentFilterParam) {
+        Page<Comment> commentPage = commentRepository.findCommentPage(pagingParam, commentFilterParam);
+
+        return new CustomPage<>(
+                commentPage.getTotalElements(),
+                commentPage.getTotalPages(),
+                commentPage.getNumber(),
+                commentPage.getContent().stream()
+                        .map(CommentPublic::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public CustomPage<CommentPublic> getMyCommentPage(PagingParam pagingParam, Long userId) {
+        Page<Comment> commentPage = commentRepository.findMyCommentPage(pagingParam, userId);
+
+        return new CustomPage<>(
+                commentPage.getTotalElements(),
+                commentPage.getTotalPages(),
+                commentPage.getNumber(),
+                commentPage.getContent().stream()
+                        .map(CommentPublic::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public CommentPublic addComment(CommentFilterParam commentFilterParam, CommentRequest commentRequest, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+
+        Course course = Course.builder().build();
+        course.setId(commentFilterParam.getCourseId());
+
+        Comment parent = null;
+        if (commentFilterParam.getParentId() != null) {
+            parent = Comment.builder().build();
+            parent.setId(commentFilterParam.getParentId());
+        }
+
+        Comment comment = Comment.builder()
+                .user(user)
+                .course(course)
+                .content(commentRequest.getContent())
+                .parent(parent)
+                .build();
+        commentRepository.save(comment);
+
+        return CommentPublic.from(comment);
+    }
+
+    public CommentPublic modifyComment(Long commentId, CommentRequest commentRequest, Long userId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        comment.setContent(commentRequest.getContent());
+
+        return CommentPublic.from(comment);
+    }
+
+    public void removeComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        commentRepository.delete(comment);
+    }
+
+}

--- a/src/main/java/app/hdj/datepick/domain/course/controller/CourseController.java
+++ b/src/main/java/app/hdj/datepick/domain/course/controller/CourseController.java
@@ -7,7 +7,6 @@ import app.hdj.datepick.domain.course.service.CoursePickService;
 import app.hdj.datepick.domain.course.service.CoursePlaceService;
 import app.hdj.datepick.domain.course.service.CourseService;
 import app.hdj.datepick.domain.relation.dto.CoursePlacePublic;
-import app.hdj.datepick.domain.relation.entity.CoursePlaceRelation;
 import app.hdj.datepick.global.annotation.ImageFile;
 import app.hdj.datepick.global.annotation.ValueOfEnum;
 import app.hdj.datepick.global.common.CustomPage;

--- a/src/main/java/app/hdj/datepick/domain/course/dto/CourseRequest.java
+++ b/src/main/java/app/hdj/datepick/domain/course/dto/CourseRequest.java
@@ -8,11 +8,8 @@ import javax.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@ToString
 @Getter
-@Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class CourseRequest {
 
     @NotEmpty

--- a/src/main/java/app/hdj/datepick/domain/course/service/CourseService.java
+++ b/src/main/java/app/hdj/datepick/domain/course/service/CourseService.java
@@ -66,9 +66,9 @@ public class CourseService {
     }
 
     public CustomPage<CoursePublic> getCoursePage(PagingParam pagingParam,
-                                            CustomSort customSort,
-                                            CourseFilterParam courseFilterParam,
-                                            Long userId) {
+                                                  CustomSort customSort,
+                                                  CourseFilterParam courseFilterParam,
+                                                  Long userId) {
         Sort sort = CustomSort.toSort(customSort, CustomSort.LATEST);
         Page<Course> coursePage = courseRepository.findCoursePage(courseFilterParam, pagingParam, sort);
 

--- a/src/main/java/app/hdj/datepick/global/config/security/SecurityConfig.java
+++ b/src/main/java/app/hdj/datepick/global/config/security/SecurityConfig.java
@@ -45,6 +45,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.GET, "/v1/courses/{\\d+}/places").permitAll()
                     .antMatchers("/v1/courses/{\\d+}").hasAuthority("USER")
                     .antMatchers("/v1/courses/{\\d+}/**").hasAuthority("USER")
+                    // Comment
+                    .antMatchers(HttpMethod.GET, "/v1/comments").permitAll()
+                    .antMatchers("/v1/comments/**").hasAuthority("USER")
 
                     .anyRequest().permitAll()
 


### PR DESCRIPTION
## 작업 프로젝트 링크
- [DATEPICK-209 | Comments API 구현](https://handongju.atlassian.net/browse/DATEPICK-209)

## 작업한 내용
- [x] Comments API 구현

## 비고
- Request DTO들 모두 `@NoArgsConstructor`, `@Getter` 만 있으면 생성됨 (추후에 모두 수정 해야됨)
- `GET /comments?course_id={id}` 는 대댓글은 제외하고 모든 댓글을 가져오고, `GET /comments?course_id={id}&parent_id={parentId}` 는 대댓글만 가져옴
- `GET /comments/me` 는 댓글, 대댓글 구분안하고 내 댓글을 모두 가져옴
